### PR TITLE
DiscordコミュニティーとDeepWikiの情報を追加

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,27 +9,50 @@ Rustは速度、安全性、平行性の3つのゴールにフォーカスした
 
 [rust-lang]: https://www.rust-lang.org/ja-JP/
 
-
 ### 日本語ドキュメント
 
 Rustに関する日本語版のドキュメントはこちらにあります。
 
-- [https://doc.rust-jp.rs](https://doc.rust-jp.rs)
+- <https://doc.rust-jp.rs> （非公式）
+    - The Rust Programming Language等の公式ドキュメントの日本語訳
+- <https://rsdocsjp.org/> （非公式）
+    - Rust標準ライブラリおよび関連仕様について、公式ドキュメントの単純な翻訳ではなく、各ライターの理解と解釈に基づいて日本語で解説する非公式プロジェクト
+    - GitHubリポジトリ: <https://github.com/Rust-Developers-JP/rsdocsjp>
+
+#### DeepWiki
+
+Rustの標準ライブラリーや外部クレートの使い方を調べたいときは、DeepWikiが便利です。
+生成AIによるWiki記事は英語ですが、AIチャットボットに日本語で質問すると日本語で回答してくれます。
+
+- 例：Rust言語と標準ライブラリーについて: https://deepwiki.com/rust-lang/rust
+
+GitHubのリポジトリーURLの`github.com`を`deepwiki.com`に置き換えると、DeepWiki上でそのリポジトリーのドキュメントを閲覧できます。
+
+また、トップページ [https://deepwiki.com](https://deepwiki.com) の検索ボックスにキーワードを入力して検索することもできます。
 
 
 ### 日本語コミュニティ
 
-Rustユーザーが（主に）日本語で情報共有することを目的としたオンライン・コミュニティがあります。
+Rustユーザーが主に日本語で情報共有することを目的としたオンライン・コミュニティがあります。
 日本で開催されるイベントの情報などもアナウンスされます。
 
-リアルタイムコミュニケーションツールとして[Zulip][zulip]チャットを活用しています。
-日本語が不得意でも問題ありません。どなたでも参加できます。
+#### Zulipチャット
 
-- [https://rust-lang-jp.zulipchat.com](https://rust-lang-jp.zulipchat.com)
+[Zulip][zulip]チャット上の日本語コミュニティです（非公式）。
+
+- <https://rust-lang-jp.zulipchat.com>
 
 メッセージを読むだけならユーザー登録は不要です。
-メッセージを投稿したり、メッセージの未読・既読を管理したりするには、
-[ここから][rust-jp-zulip-reg] ユーザー登録してください。
+メッセージを投稿したり、メッセージの未読・既読を管理したりするには、[ここから][rust-jp-zulip-reg] ユーザー登録してください。
 
 [rust-jp-zulip-reg]: https://rust-lang-jp.zulipchat.com/register/
 [zulip]: https://zulip.com/
+
+#### Discordチャット
+
+Discord上の日本語コミュニティです（非公式）。
+テキストチャットや音声チャットでRustに関する質問や議論が行われています。
+
+参加は [こちら][rust-jp-discord-invitation]。
+
+[rust-jp-discord-invitation]: https://discord.com/invite/KDCDNtxzB9

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ Rustの標準ライブラリーや外部クレートの使い方を調べたい�
 
 GitHubのリポジトリーURLの`github.com`を`deepwiki.com`に置き換えると、DeepWiki上でそのリポジトリーのドキュメントを閲覧できます。
 
-また、トップページ [https://deepwiki.com](https://deepwiki.com) の検索ボックスにキーワードを入力して検索することもできます。
+また、トップページ <https://deepwiki.com> の検索ボックスにキーワードを入力して検索することもできます。
 
 
 ### 日本語コミュニティ

--- a/index.md
+++ b/index.md
@@ -21,12 +21,12 @@ Rustに関する日本語版のドキュメントはこちらにあります。
 
 #### DeepWiki
 
-Rustの標準ライブラリーや外部クレートの使い方を調べたいときは、DeepWikiが便利です。
+Rustの標準ライブラリや外部クレートの使い方を調べたいときは、DeepWikiが便利です。
 生成AIによるWiki記事は英語ですが、AIチャットボットに日本語で質問すると日本語で回答してくれます。
 
-- 例：Rust言語と標準ライブラリーについて: <https://deepwiki.com/rust-lang/rust>
+- 例：Rust言語と標準ライブラリについて: https://deepwiki.com/rust-lang/rust
 
-GitHubのリポジトリーURLの`github.com`を`deepwiki.com`に置き換えると、DeepWiki上でそのリポジトリーのドキュメントを閲覧できます。
+GitHubのリポジトリURLの`github.com`を`deepwiki.com`に置き換えると、DeepWiki上でそのリポジトリのドキュメントを閲覧できます。
 
 また、トップページ <https://deepwiki.com> の検索ボックスにキーワードを入力して検索することもできます。
 

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ Rustに関する日本語版のドキュメントはこちらにあります。
 Rustの標準ライブラリーや外部クレートの使い方を調べたいときは、DeepWikiが便利です。
 生成AIによるWiki記事は英語ですが、AIチャットボットに日本語で質問すると日本語で回答してくれます。
 
-- 例：Rust言語と標準ライブラリーについて: https://deepwiki.com/rust-lang/rust
+- 例：Rust言語と標準ライブラリーについて: <https://deepwiki.com/rust-lang/rust>
 
 GitHubのリポジトリーURLの`github.com`を`deepwiki.com`に置き換えると、DeepWiki上でそのリポジトリーのドキュメントを閲覧できます。
 


### PR DESCRIPTION
- Discordコミュニティーの紹介を追加する
    - 招待リンクは [KaiTomotakeさんのプロフィールページ](https://github.com/KaiTomotake) にあるものを使用
- https://rsdocsjp.org/ の紹介を追加する
- DeepWikiの紹介を追加する